### PR TITLE
fix: Update phone number styling to match email

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
                     </div>
                     <div class="contact-item">
                         <i class="fas fa-phone"></i>
-                        <p>+30 6972 322 382</p>
+                        <p><a href="tel:+306972322382">+30 6972 322 382</a></p>
                     </div>
                     <div class="social-links">
                         <a href="https://www.linkedin.com/in/hsyntyhakis/" class="social-link" target="_blank"><i class="fab fa-linkedin"></i></a>


### PR DESCRIPTION
Wrapped the phone number in an anchor tag with a 'tel:' URI to ensure its styling is consistent with the email address link in the contact section.