### PR TITLE
Fix timing issue with particles initialization

### DIFF
--- a/assets/js/interactive.js
+++ b/assets/js/interactive.js
@@ -276,8 +276,6 @@ function initParticles() {
     });
 }
 
-// Override the initParticles function in main.js
-document.addEventListener('DOMContentLoaded', function() {
-  // Replace the original initParticles function
-  window.initParticles = initParticles;
-});
+// Override the initParticles function in main.js before DOMContentLoaded fires
+// so that main.js uses this version when initializing the particles background
+window.initParticles = initParticles;


### PR DESCRIPTION
## Summary
- ensure interactive.js overrides `initParticles` before DOMContentLoaded so the custom configuration is used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404beeb13c8333bc376bd86e131394